### PR TITLE
[payment] update supabase client imports

### DIFF
--- a/src/components/payment/RegisterUser.ts
+++ b/src/components/payment/RegisterUser.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { toast } from 'sonner';
 import { TokenData } from './utils/paymentHelpers';
 import { Json } from '@/integrations/supabase/types';

--- a/src/components/payment/SubscriptionManager.tsx
+++ b/src/components/payment/SubscriptionManager.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { Loader2, RefreshCw, AlertTriangle, CheckCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 

--- a/src/components/payment/services/paymentService.ts
+++ b/src/components/payment/services/paymentService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { TokenData } from '@/types/payment';
 import { RegistrationResult } from '../hooks/types';
 import { toast } from 'sonner'; 

--- a/src/components/payment/services/recoveryService.ts
+++ b/src/components/payment/services/recoveryService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 
 // Send a recovery email to the user after a payment failure
 export const sendRecoveryEmail = async (

--- a/src/components/payment/utils/errorHandling.ts
+++ b/src/components/payment/utils/errorHandling.ts
@@ -1,6 +1,6 @@
 
 import { toast } from 'sonner';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 
 // Common CardCom and payment provider error codes mapped to user-friendly messages
 export const ERROR_CODES = {

--- a/src/components/subscription/payment/hooks/usePaymentInitialization.ts
+++ b/src/components/subscription/payment/hooks/usePaymentInitialization.ts
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { toast } from 'sonner';
 import { useSubscriptionContext } from '@/contexts/subscription/SubscriptionContext';
 import { useAuth } from '@/contexts/auth';

--- a/src/components/subscription/payment/hooks/usePaymentProcessing.ts
+++ b/src/components/subscription/payment/hooks/usePaymentProcessing.ts
@@ -1,7 +1,7 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 
 export const usePaymentProcessing = () => {
   const registerNewUser = async (registrationData: any) => {

--- a/src/services/contracts/secureSignatureService.ts
+++ b/src/services/contracts/secureSignatureService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { ContractSignatureData } from '@/types/payment';
 import { toast } from 'sonner';
 

--- a/src/services/errors/utils/errorTracking.ts
+++ b/src/services/errors/utils/errorTracking.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { ErrorTrackingData } from '../types/errorTypes';
 
 /**

--- a/src/services/registration/registerUser.ts
+++ b/src/services/registration/registerUser.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { TokenData, RegistrationData, ContractSignatureData } from '@/types/payment';
 
 interface RegisterUserParams {

--- a/src/services/subscription/actions/cancelSubscription.ts
+++ b/src/services/subscription/actions/cancelSubscription.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { ActionResult } from '../types';
 import { logError } from '@/services/errors/utils/errorTracking';
 

--- a/src/services/subscription/actions/checkSubscriptionStatus.ts
+++ b/src/services/subscription/actions/checkSubscriptionStatus.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { Subscription, ActionResult } from '../types';
 import { logError } from '@/services/errors/utils/errorTracking';
 

--- a/src/services/subscription/actions/fetchCancellationData.ts
+++ b/src/services/subscription/actions/fetchCancellationData.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { CancellationData, ActionResult } from '../types';
 import { logError } from '@/services/errors/utils/errorTracking';
 

--- a/src/services/subscription/actions/reactivateSubscription.ts
+++ b/src/services/subscription/actions/reactivateSubscription.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/lib/supabase-client';
 import { ActionResult } from '../types';
 import { logError } from '@/services/errors/utils/errorTracking';
 


### PR DESCRIPTION
## Summary
- use `@/lib/supabase-client` instead of `@/integrations/supabase/client`
- update payment modules, hooks, and services

## Testing
- `npm run lint` *(fails: 449 errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*