### PR TITLE
[payment] use string operations for CardCom

### DIFF
--- a/supabase/functions/cardcom-payment/index.ts
+++ b/supabase/functions/cardcom-payment/index.ts
@@ -40,6 +40,12 @@ enum OperationType {
   TOKEN_ONLY = 3,         // Create token only (for future charges)
 }
 
+const OPERATION_MAP: Record<OperationType, string> = {
+  [OperationType.CHARGE_ONLY]: 'ChargeOnly',
+  [OperationType.CHARGE_AND_TOKEN]: 'ChargeAndCreateToken',
+  [OperationType.TOKEN_ONLY]: 'CreateTokenOnly'
+};
+
 // Create a payment session with CardCom API v11
 async function createPaymentSession(params: any) {
   const { 
@@ -61,6 +67,9 @@ async function createPaymentSession(params: any) {
   }
   
   try {
+    const operationString = OPERATION_MAP[operationType as OperationType] ||
+      'CreateTokenOnly';
+
     // Prepare the request payload for LowProfile Create
     const payload = {
       TerminalNumber: parseInt(API_CONFIG.TERMINAL),
@@ -70,7 +79,7 @@ async function createPaymentSession(params: any) {
       SuccessRedirectUrl: successUrl,
       FailedRedirectUrl: errorUrl,
       WebHookUrl: webHookUrl,
-      Operation: operationType.toString(),
+      Operation: operationString,
       Language: "he",
       ISOCoinId: 1, // ILS
       
@@ -91,10 +100,10 @@ async function createPaymentSession(params: any) {
       }
     };
 
-    console.log('Creating CardCom payment session:', { 
-      planId, 
-      amount, 
-      operationType,
+    console.log('Creating CardCom payment session:', {
+      planId,
+      amount,
+      operation: operationString,
       webhookConfigured: !!webHookUrl
     });
     

--- a/supabase/functions/iframe-redirect/index.ts
+++ b/supabase/functions/iframe-redirect/index.ts
@@ -43,12 +43,34 @@ serve(async (req) => {
       );
     }
 
+    // Convert numeric operation to string enum expected by CardCom
+    let operation = requestData.operation;
+    if (typeof operation === 'number') {
+      switch (operation) {
+        case 1:
+          operation = 'ChargeOnly';
+          break;
+        case 2:
+          operation = 'ChargeAndCreateToken';
+          break;
+        case 3:
+          operation = 'CreateTokenOnly';
+          break;
+      }
+    } else if (operation === '1') {
+      operation = 'ChargeOnly';
+    } else if (operation === '2') {
+      operation = 'ChargeAndCreateToken';
+    } else if (operation === '3') {
+      operation = 'CreateTokenOnly';
+    }
+
     // Build request body for Cardcom API
     const cardcomRequestBody = {
       TerminalNumber: requestData.terminalNumber,
       ApiName: requestData.apiName,
       // Include the operation (e.g. ChargeAndCreateToken) for recurring payments
-      Operation: requestData.operation || "ChargeAndCreateToken",
+      Operation: operation || "ChargeAndCreateToken",
       Amount: requestData.amount,
       SuccessRedirectUrl: requestData.successUrl,
       FailedRedirectUrl: requestData.failedUrl,


### PR DESCRIPTION
## Summary
- map numeric operation type codes to CardCom v11 strings
- sanitize iframe-redirect operation input to convert to the enum names

## Testing
- `npm run lint` *(fails: 434 errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*