### PR TITLE
[payments] use v11 CardCom verification endpoint

### DIFF
--- a/supabase/functions/verify-cardcom-payment/index.ts
+++ b/supabase/functions/verify-cardcom-payment/index.ts
@@ -196,7 +196,7 @@ serve(async (req) => {
       { lowProfileId }
     );
 
-    const cardcomResponse = await fetch('https://secure.cardcom.solutions/api/v1/LowProfile/GetLpResult', {
+    const cardcomResponse = await fetch('https://secure.cardcom.solutions/api/v11/LowProfile/GetLpResult', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- point CardCom verification to the v11 API

## Testing
- `npm run lint` *(fails: 434 errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*
