### PR TITLE
[subscription] end trials for annual and vip

### DIFF
--- a/src/components/SubscriptionPlans.tsx
+++ b/src/components/SubscriptionPlans.tsx
@@ -42,7 +42,7 @@ const SubscriptionPlans: React.FC<SubscriptionPlansProps> = ({
       </div>
       
       <div className="text-center text-sm text-muted-foreground mt-6">
-        <p>* כל התכניות (חודשי ושנתי) כוללות חודש ניסיון חינם. ניתן לבטל בכל עת ללא התחייבות.</p>
+        <p>* המסלול החודשי כולל חודש ניסיון חינם. ניתן לבטל בכל עת ללא התחייבות.</p>
       </div>
     </div>
   );

--- a/src/components/payment/RegisterUser.ts
+++ b/src/components/payment/RegisterUser.ts
@@ -51,8 +51,12 @@ export const registerUser = async (
     // Add a delay to ensure the user is created before proceeding
     await new Promise(resolve => setTimeout(resolve, 1000));
     
-    const trialEndsAt = new Date();
-    trialEndsAt.setMonth(trialEndsAt.getMonth() + 1); // 1 month trial
+    const isMonthlyPlan = registrationData.planId === 'monthly';
+    let trialEndsAt: Date | null = null;
+    if (isMonthlyPlan) {
+      trialEndsAt = new Date();
+      trialEndsAt.setMonth(trialEndsAt.getMonth() + 1); // 1 month trial
+    }
     
     // Convert TokenData to Json type for Supabase
     const paymentMethodJson = tokenData as unknown as Json;
@@ -63,8 +67,8 @@ export const registerUser = async (
       .insert({
         user_id: userData.user.id,
         plan_type: registrationData.planId,
-        status: 'trial',
-        trial_ends_at: trialEndsAt.toISOString(),
+        status: isMonthlyPlan ? 'trial' : 'active',
+        trial_ends_at: trialEndsAt ? trialEndsAt.toISOString() : null,
         payment_method: paymentMethodJson,
         contract_signed: true,
         contract_signed_at: new Date().toISOString()

--- a/src/services/registration/registerUser.ts
+++ b/src/services/registration/registerUser.ts
@@ -100,8 +100,12 @@ export const registerUser = async ({
     // Add a delay to ensure the user record is propagated
     await new Promise(resolve => setTimeout(resolve, 1000));
     
-    const trialEndsAt = new Date();
-    trialEndsAt.setMonth(trialEndsAt.getMonth() + 1); // 1 month trial
+    const isMonthlyPlan = registrationData.planId === 'monthly';
+    let trialEndsAt: Date | null = null;
+    if (isMonthlyPlan) {
+      trialEndsAt = new Date();
+      trialEndsAt.setMonth(trialEndsAt.getMonth() + 1); // 1 month trial
+    }
     
     // Create the subscription record - Convert TokenData to a regular object for storage
     const paymentMethodData = {
@@ -118,8 +122,8 @@ export const registerUser = async ({
       .insert({
         user_id: userData.user.id,
         plan_type: registrationData.planId,
-        status: 'trial',
-        trial_ends_at: trialEndsAt.toISOString(),
+        status: isMonthlyPlan ? 'trial' : 'active',
+        trial_ends_at: trialEndsAt ? trialEndsAt.toISOString() : null,
         payment_method: paymentMethodData, // Using the simplified object
         contract_signed: true,
         contract_signed_at: new Date().toISOString()

--- a/supabase/functions/register-user/index.ts
+++ b/supabase/functions/register-user/index.ts
@@ -80,8 +80,12 @@ serve(async (req) => {
 
     console.log('User created successfully:', userData.user.id);
 
-    const trialEndsAt = new Date();
-    trialEndsAt.setMonth(trialEndsAt.getMonth() + 1); // 1 month trial
+    const isMonthlyPlan = registrationData.planId === 'monthly';
+    let trialEndsAt: Date | null = null;
+    if (isMonthlyPlan) {
+      trialEndsAt = new Date();
+      trialEndsAt.setMonth(trialEndsAt.getMonth() + 1); // 1 month trial
+    }
 
     // Determine payment method from either tokenData or registrationData.paymentToken
     const paymentMethod = tokenData || registrationData.paymentToken || null;
@@ -92,8 +96,8 @@ serve(async (req) => {
       .insert({
         user_id: userData.user.id,
         plan_type: registrationData.planId,
-        status: 'trial',
-        trial_ends_at: trialEndsAt.toISOString(),
+        status: isMonthlyPlan ? 'trial' : 'active',
+        trial_ends_at: trialEndsAt ? trialEndsAt.toISOString() : null,
         payment_method: paymentMethod,
         contract_signed: true,
         contract_signed_at: new Date().toISOString()


### PR DESCRIPTION
## Summary
- adjust register-user edge function so only monthly plans have a trial
- keep client RegisterUser helpers in sync
- update plan note in SubscriptionPlans

## Testing
- `npm run lint` *(fails: 434 errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*