### PR TITLE
[payments] unify token table

### DIFF
--- a/src/components/payment/SubscriptionManager.tsx
+++ b/src/components/payment/SubscriptionManager.tsx
@@ -83,7 +83,7 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({
       
       // Check for payment tokens
       const { data: tokenData, error: tokenError } = await supabase
-        .from('recurring_payments')
+        .from('payment_tokens')
         .select('*')
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
@@ -93,10 +93,10 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({
         setDiagnosticInfo(prev => ({
           ...prev,
           hasToken: true,
-          tokenStatus: tokenData[0].status,
-          tokenValid: tokenData[0].is_valid,
+          tokenStatus: tokenData[0].is_active ? 'active' : 'inactive',
+          tokenValid: tokenData[0].is_active,
           tokenExpiry: tokenData[0].token_expiry,
-          last4Digits: tokenData[0].last_4_digits
+          last4Digits: tokenData[0].card_last_four
         }));
       } else {
         setDiagnosticInfo(prev => ({

--- a/src/contexts/subscription/SubscriptionContext.tsx
+++ b/src/contexts/subscription/SubscriptionContext.tsx
@@ -210,16 +210,16 @@ export const SubscriptionProvider: React.FC<SubscriptionProviderProps> = ({ chil
       
       // Check if we have a valid recurring payment token
       if (data.status === 'active' && !data.token) {
-        console.log('Active subscription without token, checking recurring_payments');
+        console.log('Active subscription without token, checking payment_tokens');
         
         try {
-          // Try to find a token in recurring_payments
+          // Try to find a token in payment_tokens
           // FIX: Use ISO datetime comparison instead of just date comparison to properly handle timezones
           const { data: recurringPayments, error: recurringError } = await supabase
-            .from('recurring_payments')
-            .select('token, token_expiry, is_valid')
+            .from('payment_tokens')
+            .select('token, token_expiry, is_active')
             .eq('user_id', userId)
-            .eq('is_valid', true)
+            .eq('is_active', true)
             .gte('token_expiry', new Date().toISOString().split('T')[0]) // Using date part only is fine since token_expiry is a date without time
             .order('created_at', { ascending: false })
             .limit(1);
@@ -236,7 +236,7 @@ export const SubscriptionProvider: React.FC<SubscriptionProviderProps> = ({ chil
             // Additional validation to ensure token is not expired
             // This uses date-fns to properly compare dates
             if (isAfter(tokenExpiryDate, today)) {
-              console.log('Found valid token in recurring_payments, syncing to subscription');
+              console.log('Found valid token in payment_tokens, syncing to subscription');
               
               // Update subscription with token
               const { error: updateError } = await supabase

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -127,30 +127,30 @@ export const useSubscription = (): UseSubscriptionReturn => {
         }
       }
       
-      // Also check recurring_payments table for this user
+      // Also check payment_tokens table for this user
       const { data: recurringPayments, error: recurringError } = await supabase
-        .from('recurring_payments')
-        .select('token, is_valid, token_expiry')
+        .from('payment_tokens')
+        .select('token, is_active, token_expiry')
         .eq('user_id', user.id)
-        .eq('is_valid', true)
+        .eq('is_active', true)
         .gte('token_expiry', new Date().toISOString().split('T')[0])
         .limit(1);
         
       if (recurringError) {
-        console.error('Error checking recurring payments:', recurringError);
+        console.error('Error checking payment tokens:', recurringError);
       } else {
         if (recurringPayments && recurringPayments.length === 0 && subscription) {
-          console.log('User has subscription but no valid recurring payment token');
+          console.log('User has subscription but no valid payment token');
           // This indicates a potential inconsistency that might need fixing
           return true;
         }
         
-        // Check if there's a mismatch between subscription and recurring_payments
+        // Check if there's a mismatch between subscription and payment_tokens
         if (recurringPayments?.length > 0 && subscription) {
           const recurringToken = recurringPayments[0].token;
           
           if (subscription.token !== recurringToken) {
-            console.log('Token mismatch between subscription and recurring_payments');
+            console.log('Token mismatch between subscription and payment_tokens');
             // There's an inconsistency that needs to be fixed
             return true;
           }

--- a/src/services/debugging/paymentDebugger.ts
+++ b/src/services/debugging/paymentDebugger.ts
@@ -271,17 +271,20 @@ export class PaymentDebugger {
           return false;
         }
         
+        await supabase
+          .from('payment_tokens')
+          .update({ is_active: false, updated_at: new Date().toISOString() })
+          .eq('user_id', userId);
+
         const { error: tokenError } = await supabase
-          .from('recurring_payments')
+          .from('payment_tokens')
           .insert({
             user_id: userId,
             token: paymentData.token_info.token,
             token_expiry: paymentData.token_info.expiry,
-            token_approval_number: paymentData.token_info.approval || '', // Provide empty string if null
-            last_4_digits: paymentData.card_info?.last4 || null,
-            card_type: paymentData.card_info?.card_type || null,
-            status: 'active',
-            is_valid: true,
+            card_last_four: paymentData.card_info?.last4 || null,
+            card_brand: paymentData.card_info?.card_type || null,
+            is_active: true,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString()
           });

--- a/src/services/registration/registerUser.ts
+++ b/src/services/registration/registerUser.ts
@@ -138,16 +138,21 @@ export const registerUser = async ({
         const expiryDate = new Date();
         expiryDate.setFullYear(expiryDate.getFullYear() + 5); // 5 years validity for card token
         
-        // Insert token data into recurring_payments table
-        await supabase.from('recurring_payments').insert({
+        // Mark existing tokens inactive and save the new token
+        await supabase
+          .from('payment_tokens')
+          .update({ is_active: false, updated_at: new Date().toISOString() })
+          .eq('user_id', userData.user.id);
+
+        await supabase.from('payment_tokens').insert({
           user_id: userData.user.id,
           token: tokenData.token.toString(), // Ensure it's a string
           token_expiry: expiryDate.toISOString(),
-          last_4_digits: tokenData.lastFourDigits,
-          card_type: tokenData.cardType?.toString() || 'unknown',
-          status: 'active',
-          token_approval_number: tokenData.approvalNumber?.toString(),
-          is_valid: true
+          card_last_four: tokenData.lastFourDigits,
+          card_brand: tokenData.cardType?.toString() || 'unknown',
+          is_active: true,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString()
         });
           
         console.log('Payment token stored successfully');


### PR DESCRIPTION
## Summary
- update server functions to use `payment_tokens` table
- mark previous tokens inactive when saving new ones
- adjust frontend queries for new token table fields

## Testing
- `npm run lint` *(fails: 434 errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*