### PR TITLE
[payments] use ILS currency labels

### DIFF
--- a/src/components/UserSubscription.tsx
+++ b/src/components/UserSubscription.tsx
@@ -342,7 +342,7 @@ const SubscriptionDetails = ({
                   <BillingInfo 
                     nextBillingDate={details.nextBillingDate} 
                     planPrice={details.planPrice}
-                    currency="$"
+                    currency="₪"
                   />
                   
                   <PaymentMethodInfo 

--- a/src/components/payment/PaymentCardForm.tsx
+++ b/src/components/payment/PaymentCardForm.tsx
@@ -36,7 +36,7 @@ const PaymentCardForm: React.FC<PaymentCardFormProps> = ({
           price={plan.price} 
           description={plan.description}
           hasTrial={planId === 'monthly'}
-          currency="$" 
+          currency="₪"
         />
         
         <div className="bg-card rounded-xl p-6 border border-border shadow-sm">

--- a/src/components/payment/services/paymentService.ts
+++ b/src/components/payment/services/paymentService.ts
@@ -59,7 +59,7 @@ export const handleExistingUserPayment = async (
           user_id: userId,
           subscription_id: userId,
           amount: price,
-          currency: 'USD',
+          currency: 'ILS',
           status: 'completed',
           payment_method: {
             ...tokenData,
@@ -126,7 +126,7 @@ export const handleExistingUserPayment = async (
           user_id: userId,
           subscription_id: userId,
           amount: 0,
-          currency: 'USD',
+          currency: 'ILS',
           status: 'trial_started',
           payment_method: tokenData
         });

--- a/src/components/subscription/BillingInfo.tsx
+++ b/src/components/subscription/BillingInfo.tsx
@@ -11,7 +11,7 @@ interface BillingInfoProps {
 const BillingInfo: React.FC<BillingInfoProps> = ({ 
   nextBillingDate, 
   planPrice,
-  currency = '$'
+  currency = '₪'
 }) => {
   return (
     <>


### PR DESCRIPTION
## Summary
- show ₪ in billing info and subscription screens
- persist payment_history amounts in ILS

## Testing
- `npm run lint` *(fails: 434 errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*