### PR TITLE
[payment] validate iframe message origin

### DIFF
--- a/src/components/subscription/payment/PaymentIframe.tsx
+++ b/src/components/subscription/payment/PaymentIframe.tsx
@@ -32,17 +32,27 @@ const PaymentIframe: React.FC<PaymentIframeProps> = ({
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+
   // Listen for messages from the iframe
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      // For security, we should validate the origin, but for now we're using '*' in postMessage
+      const allowedOrigins = [
+        'https://secure.cardcom.solutions',
+        window.location.origin
+      ];
+
+      if (!allowedOrigins.includes(event.origin)) {
+        console.warn(`Ignored message from unauthorized origin: ${event.origin}`);
+        return;
+      }
+
       console.log('Received message from iframe:', event.data);
-      
+
       if (event.data?.type === 'cardcom-paid') {
         // Payment successful
         console.log('Payment successful:', event.data.details);
         toast.success('התשלום התקבל בהצלחה!');
-        
+
         if (onSuccess) {
           onSuccess(event.data.details);
         }
@@ -50,7 +60,7 @@ const PaymentIframe: React.FC<PaymentIframeProps> = ({
         // Payment failed
         console.error('Payment error:', event.data.message);
         toast.error('שגיאה בתהליך התשלום: ' + (event.data.message || 'אנא נסה שנית'));
-        
+
         if (onError) {
           onError(new Error(event.data.message || 'Payment failed'));
         }
@@ -60,6 +70,7 @@ const PaymentIframe: React.FC<PaymentIframeProps> = ({
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
   }, [onSuccess, onError]);
+
 
   if (!paymentUrl) return null;
 

--- a/src/components/subscription/payment/hooks/usePaymentUrlParams.ts
+++ b/src/components/subscription/payment/hooks/usePaymentUrlParams.ts
@@ -53,8 +53,18 @@ export const usePaymentUrlParams = (
     
     // Listen for payment messages from the iframe
     const handlePaymentMessage = (event: MessageEvent) => {
-      // For security, we should validate the origin
-      // but in this case we're communicating with our own page
+      const allowedOrigins = [
+        'https://secure.cardcom.solutions',
+        window.location.origin
+      ];
+
+      if (!allowedOrigins.includes(event.origin)) {
+        console.warn(
+          `Ignored message from unauthorized origin: ${event.origin}`
+        );
+        return;
+      }
+
       console.log('Received message:', event.data);
       
       if (event.data?.type === 'cardcom-paid') {


### PR DESCRIPTION
## Summary
- validate origin of postMessage events in `PaymentIframe`
- validate origin in `usePaymentUrlParams` hook

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*