### PR TITLE
[ui] use wrapped theme hook in Toaster

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from "next-themes"
+import { useTheme } from "@/hooks/use-theme"
 import { Toaster as Sonner } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>


### PR DESCRIPTION
## Summary
- adjust `Toaster` to use the wrapped `useTheme` hook

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`