### PR TITLE
[app] wrap routes with global error boundary

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -11,7 +11,7 @@ Project guides, standards, and deep-dives in `/docs`.
 - Update docs when flows, architecture, or standards change
 - Use clear Markdown: headings, lists, code blocks
 - Document decisions, rationales, gotchas
-- New docs: create descriptive filenames (e.g. `PERFORMANCE.md`, `REACT_PROFILING.md`)
+ - New docs: create descriptive filenames (e.g. `PERFORMANCE.md`, `REACT_PROFILING.md`, `GLOBAL_ERROR_HANDLING.md`)
 - Cross-link AGENTS.md, CODE_STANDARDS.md, etc., where helpful
 
 ---

--- a/docs/GLOBAL_ERROR_HANDLING.md
+++ b/docs/GLOBAL_ERROR_HANDLING.md
@@ -1,0 +1,15 @@
+# Global Error Handling
+
+This document describes the error boundary strategy used in AlgoTouch.
+
+## Global boundary
+
+`App.tsx` wraps the application's `<Routes>` component in `ErrorBoundary` from `src/components/errors`. Any uncaught error in route components will surface through this boundary and render a default fallback.
+
+## Page specific boundaries
+
+Pages can still include their own `ErrorBoundary` components when they need custom fallback UI or recovery behavior. If a page has no custom fallback it should rely on the global boundary instead of wrapping its content repeatedly.
+
+## Development notes
+
+When adding new routes or pages, ensure they work with the global error boundary. Provide custom fallbacks only when the page requires special handling or messaging.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/contexts/auth';
 import { DirectionProvider } from '@/contexts/direction/DirectionProvider';
 import { StockDataProvider } from '@/contexts/stock/StockDataContext';
 import ProtectedRoute from '@/components/ProtectedRoute';
+import ErrorBoundary from '@/components/errors/ErrorBoundary';
 
 // Eagerly loaded routes for critical paths
 import Auth from '@/pages/Auth';
@@ -94,7 +95,8 @@ function App() {
     <BrowserRouter>
       <DirectionProvider dir="rtl">
         <Suspense fallback={<LoadingPage />}>
-          <Routes>
+          <ErrorBoundary>
+            <Routes>
             {/* Auth Error Route */}
             <Route path="/auth-error" element={<AuthLoadError />} />
             
@@ -144,6 +146,7 @@ function App() {
               <Route path="*" element={<NotFound />} />
             </Route>
           </Routes>
+        </ErrorBoundary>
         </Suspense>
         <Toaster richColors position="top-center" dir="rtl" />
       </DirectionProvider>


### PR DESCRIPTION
## Summary
- wrap Routes with ErrorBoundary in `App.tsx`
- document global error handling strategy

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*