### PR TITLE
[edge] add health-check function

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -13,6 +13,7 @@ Project guides, standards, and deep-dives in `/docs`.
 - Document decisions, rationales, gotchas
 - New docs: create descriptive filenames (e.g. `PERFORMANCE.md`, `REACT_PROFILING.md`)
 - Cross-link AGENTS.md, CODE_STANDARDS.md, etc., where helpful
+- See `UPTIME_MONITORING.md` for health check setup
 
 ---
 

--- a/docs/UPTIME_MONITORING.md
+++ b/docs/UPTIME_MONITORING.md
@@ -1,0 +1,17 @@
+# Uptime Monitoring
+
+This project exposes a simple health check Edge Function for uptime tools.
+
+## Health Check Endpoint
+
+- **URL:** `/functions/v1/health-check`
+- **Response:** `{"status":"ok"}`
+
+### Usage
+
+1. Deploy the `health-check` function to your Supabase project.
+2. Configure your uptime service (e.g. UptimeRobot, StatusCake) to send a `GET` request to the endpoint.
+3. The service should expect a `200` status code and the JSON body shown above.
+4. Trigger alerts if the request fails or returns a non-200 response.
+
+The function handles CORS and does not require authentication, making it safe for public monitoring.

--- a/supabase/functions/health-check/index.ts
+++ b/supabase/functions/health-check/index.ts
@@ -1,0 +1,22 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+// Basic CORS headers for public checks
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+};
+
+serve(async (req: Request) => {
+  // Respond to CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders, status: 204 });
+  }
+
+  console.log('Health check');
+
+  return new Response(
+    JSON.stringify({ status: 'ok' }),
+    { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
+  );
+});


### PR DESCRIPTION
## Summary
- add a simple `health-check` Supabase Edge Function
- document how to use the endpoint with uptime tools
- mention health check doc in `/docs/AGENTS.md`

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*