### PR TITLE
[core] remove next-themes integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "input-otp": "^1.4.2",
         "lighthouse-ci": "^1.13.1",
         "lucide-react": "^0.462.0",
-        "next-themes": "^0.3.0",
         "papaparse": "^5.5.3",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -8455,16 +8454,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-themes": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
-      "integrity": "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "input-otp": "^1.4.2",
     "lighthouse-ci": "^1.13.1",
     "lucide-react": "^0.462.0",
-    "next-themes": "^0.3.0",
     "papaparse": "^5.5.3",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/src/contexts/theme/context.tsx
+++ b/src/contexts/theme/context.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setThemeState] = useState<Theme>('dark')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored) {
+      setThemeState(stored)
+      applyTheme(stored)
+    } else {
+      applyTheme('dark')
+    }
+  }, [])
+
+  const applyTheme = (newTheme: Theme) => {
+    document.documentElement.classList.remove('light', 'dark')
+    document.documentElement.classList.add(newTheme)
+  }
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme)
+    localStorage.setItem('theme', newTheme)
+    applyTheme(newTheme)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/src/contexts/theme/index.tsx
+++ b/src/contexts/theme/index.tsx
@@ -1,15 +1,1 @@
-
-import React from 'react';
-import { ThemeProvider as NextThemesProvider } from 'next-themes';
-
-// Re-export the hook
-export { useTheme } from '@/hooks/use-theme';
-
-// For backward compatibility, we wrap the next-themes provider
-export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <NextThemesProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      {children}
-    </NextThemesProvider>
-  );
-};
+export { ThemeProvider, ThemeContext, type Theme } from './context'

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,26 +1,18 @@
+import { useContext } from 'react'
+import { ThemeContext, Theme } from '@/contexts/theme'
 
-import { useTheme as useNextThemes } from 'next-themes';
-
-// Export the hook with the same interface as our previous custom hook
 export const useTheme = () => {
-  // Use try-catch to handle potential initialization issues
-  try {
-    const { theme, setTheme, resolvedTheme } = useNextThemes();
-    
-    return { 
-      theme, 
-      setTheme,
-      resolvedTheme 
-    };
-  } catch (error) {
-    // Fallback if next-themes isn't initialized yet
-    console.error('Theme hook error:', error);
+  const ctx = useContext(ThemeContext)
+  if (!ctx) {
+    console.warn('useTheme must be used within ThemeProvider')
     return {
-      theme: 'dark',
-      setTheme: () => console.warn('Theme provider not ready'),
-      resolvedTheme: 'dark'
-    };
+      theme: 'dark' as Theme,
+      setTheme: () => {
+        /* noop */
+      }
+    }
   }
-};
+  return ctx
+}
 
-export default useTheme;
+export default useTheme


### PR DESCRIPTION
## Summary
- replace next-themes with a custom theme provider
- export a small `useTheme` hook backed by React context
- clean up package dependencies

## Testing
- `npm run lint` *(fails: 434 errors in repo)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*