### PR TITLE
[config] dedupe react dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => ({
       "react": path.resolve(__dirname, "./node_modules/react"),
       "react-dom": path.resolve(__dirname, "./node_modules/react-dom")
     },
+    dedupe: ["react", "react-dom"],
   },
   build: {
     // Force inline critical modules


### PR DESCRIPTION
## Summary
- ensure Vite dedupes react packages when bundling

## Testing
- `npm run build`
- `npm run lint` *(fails: 433 errors)*
- `npx playwright test` *(fails: Timed out waiting for web server)*