### PR TITLE
[ui] fix provider hook usage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
-import { Toaster } from 'sonner';
+import { Toaster } from '@/components/ui/sonner';
 import { Spinner } from '@/components/ui/spinner';
 import { AuthProvider } from '@/contexts/auth';
 import { DirectionProvider } from '@/contexts/direction/DirectionProvider';

--- a/src/contexts/direction/DirectionProvider.tsx
+++ b/src/contexts/direction/DirectionProvider.tsx
@@ -1,5 +1,5 @@
 
-import React, { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 type Direction = 'ltr' | 'rtl';
 
@@ -10,20 +10,17 @@ interface DirectionContextValue {
 // Create context with a default value to avoid null checks
 const DirectionContext = createContext<DirectionContextValue>({ dir: 'rtl' });
 
-export function useDirection() {
-  const context = useContext(DirectionContext);
-  return context; // No need to check for null now
-}
+export const useDirection = () => useContext(DirectionContext);
 
 interface DirectionProviderProps {
   dir?: Direction;
   children: React.ReactNode;
 }
 
-export function DirectionProvider({
+export const DirectionProvider: React.FC<DirectionProviderProps> = ({
   dir = 'rtl', // Default to RTL based on your app's Hebrew language
   children,
-}: DirectionProviderProps) {
+}) => {
   const value = useMemo(() => ({ dir }), [dir]);
   
   return (
@@ -31,4 +28,4 @@ export function DirectionProvider({
       {children}
     </DirectionContext.Provider>
   );
-}
+};


### PR DESCRIPTION
## Summary
- fix invalid `sonner` import in `App.tsx`
- convert `DirectionProvider` to arrow function

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx playwright test` *(fails: EHOSTUNREACH when fetching playwright)*