### PR TITLE
[e2e] add login flow test

### DIFF
--- a/docs/E2E.md
+++ b/docs/E2E.md
@@ -1,0 +1,19 @@
+# End-to-End Tests
+
+This project uses **Playwright** for all automated browser tests. Tests live under the `/e2e` directory and are executed for multiple browsers as defined in `playwright.config.ts`.
+
+## Login Flow
+
+The `login-flow.spec.ts` test covers a basic authentication scenario:
+
+1. Navigate to `/auth` and submit valid credentials.
+2. Verify the app redirects to `/dashboard` and does not bounce back to `/auth`.
+3. Visit `/profile` and ensure subscription details render using `data-testid` hooks from `UserSubscription`.
+
+Run all tests with:
+
+```bash
+npx playwright test
+```
+
+Refer to `e2e/AGENTS.md` for guidelines on writing additional scenarios.

--- a/e2e/login-flow.spec.ts
+++ b/e2e/login-flow.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Login Flow', () => {
+  test('logs in and shows subscription details', async ({ page }) => {
+    await page.goto('/auth');
+
+    await page.fill('[data-testid="email"]', 'test@example.com');
+    await page.fill('[data-testid="password"]', 'password123');
+    await page.click('[data-testid="login-button"]');
+
+    await page.waitForURL('**/dashboard');
+    await expect(page).toHaveURL(/\/dashboard$/);
+    expect(page.url()).not.toContain('/auth');
+
+    await page.goto('/profile');
+    await page.waitForSelector('[data-testid="user-subscription"]', { state: 'visible' });
+    await expect(page.locator('[data-testid="user-subscription"]')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- create login-flow Playwright spec
- document the new e2e test scenario

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*