### PR TITLE
[subscription] handle subscription fetch errors

### DIFF
--- a/src/components/UserSubscription.tsx
+++ b/src/components/UserSubscription.tsx
@@ -30,7 +30,7 @@ interface WebhookCheckResult {
 const UserSubscription = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { hasActiveSubscription } = useSubscriptionContext(); // Use the computed property
+  const { hasActiveSubscription, error: subscriptionError, refreshSubscription: contextRefresh } = useSubscriptionContext();
   const { 
     subscription, 
     loading, 
@@ -166,6 +166,26 @@ const UserSubscription = () => {
       }
     }
   };
+
+  // If subscription context encountered an error, show retry UI
+  if (subscriptionError) {
+    return (
+      <SubscriptionCard
+        title="שגיאה בבדיקת פרטי המנוי"
+        description="לא ניתן למשוך את נתוני המנוי"
+      >
+        <div className="p-6">
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>{subscriptionError}</AlertDescription>
+          </Alert>
+          <Button onClick={() => contextRefresh().catch(console.error)} className="flex items-center gap-2">
+            <RefreshCw className="h-4 w-4" />
+            נסה שוב
+          </Button>
+        </div>
+      </SubscriptionCard>
+    );
+  }
 
   // Special state for when we've tried a few times and still can't load data
   if (maxRetriesReached || (checkError && retryCount >= 3)) {

--- a/tests/subscription-context.test.ts
+++ b/tests/subscription-context.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import { fetchSubscriptionRecord } from '../src/contexts/subscription/SubscriptionContext';
+import { supabase } from '../src/integrations/supabase/client';
+
+// Use ts-node loader when running this test:
+// node --test --loader ts-node/esm tests/subscription-context.test.ts
+
+test('fetchSubscriptionRecord throws on query failure', async () => {
+  const restore = mock.method(supabase, 'from', () => ({
+    select: () => ({
+      eq: () => ({
+        maybeSingle: async () => ({ data: null, error: new Error('fail') })
+      })
+    })
+  }));
+
+  await assert.rejects(() => fetchSubscriptionRecord('1'), /fail/);
+  restore.mock.restore();
+});


### PR DESCRIPTION
## Summary
- expose `fetchSubscriptionRecord` helper
- preserve subscription data on fetch errors and surface message in context
- show retry UI in `UserSubscription` when subscription context has an error
- add unit test for failing subscription fetch

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*