### PR TITLE
[env] use env vars for supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the frontend
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ This project is built with .
 
 ## Required Environment Variables
 
-Supabase Edge Functions rely on several environment variables. Ensure these are set before deploying:
+Copy `.env.example` to `.env` and fill in the appropriate values. Supabase Edge Functions rely on several environment variables. Ensure these are set before deploying:
 
 - `SUPABASE_URL` – your Supabase project URL
 - `SUPABASE_ANON_KEY` – anonymous key for public calls
+- `VITE_SUPABASE_URL` – Supabase URL used by the frontend
+- `VITE_SUPABASE_ANON_KEY` – anonymous key consumed in the browser
 - `SUPABASE_SERVICE_ROLE_KEY` – service role key for privileged operations
 - `CARDCOM_TERMINAL` – CardCom terminal number
 - `CARDCOM_USERNAME` – CardCom API username

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -2,9 +2,9 @@
 import { createClient } from '@supabase/supabase-js';
 import type { ExtendedDatabase } from '@/types/supabase';
 
-// The Supabase URL and key are injected at build time
-const SUPABASE_URL = "https://ndhakvhrrkczgylcmyoc.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5kaGFrdmhycmtjemd5bGNteW9jIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI4NTUxNzIsImV4cCI6MjA1ODQzMTE3Mn0.dJg3Pe8DNXuvy4PvcBwBo64K2Le-zptEuYZtr_49xIk";
+// The Supabase URL and anon key are provided via environment variables
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Create a singleton instance of the Supabase client with proper configuration
 export const supabase = createClient<ExtendedDatabase>(


### PR DESCRIPTION
## Summary
- create `.env.example` with new Supabase variables
- read Supabase URL/key from env in `supabase-client.ts`
- document Supabase Vite variables in `README`

## Testing
- `npm run lint` *(fails: 434 errors)*
- `npm run build`
- `npx playwright test` *(fails: Timed out waiting 60000ms from config.webServer)*