### PR TITLE
[payment] improve iframe redirect error handling

### DIFF
--- a/src/components/CardcomIframeRedirect.tsx
+++ b/src/components/CardcomIframeRedirect.tsx
@@ -64,9 +64,11 @@ const CardcomIframeRedirect: React.FC<CardcomIframeRedirectProps> = ({
         } else {
           throw new Error('לא התקבל קישור תקין ממערכת הסליקה');
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
+        const errorMessage =
+          err instanceof Error ? err.message : String(err);
         console.error('Error creating iframe redirect:', err);
-        setError(err.message || 'אירעה שגיאה ביצירת עמוד התשלום');
+        setError(errorMessage);
         toast.error('שגיאה בהתחברות למערכת הסליקה');
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- catch unknown errors in the Cardcom iframe redirect
- log the unknown error and pass a clean message to the UI

## Testing
- `npx eslint src/components/CardcomIframeRedirect.tsx -f json`
- `npm run lint src/components/CardcomIframeRedirect.tsx` *(fails: 433 problems across repo)*